### PR TITLE
Fix validation for purchase amount

### DIFF
--- a/src/main/java/br/com/wexapplication/wexapp/dto/PurchaseTransactionRequest.java
+++ b/src/main/java/br/com/wexapplication/wexapp/dto/PurchaseTransactionRequest.java
@@ -3,6 +3,7 @@ package br.com.wexapplication.wexapp.dto;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,6 +25,7 @@ public class PurchaseTransactionRequest {
 
     @NotNull(message = "Field purchaseAmount must be filled.")
     @Digits(integer = 10, message = "Purchase amount must be rounded to the nearest cent.", fraction = 9)
+    @Positive(message = "Purchase amount must be a positive value.")
     private BigDecimal purchaseAmount;
 
 }

--- a/src/main/java/br/com/wexapplication/wexapp/model/PurchaseTransaction.java
+++ b/src/main/java/br/com/wexapplication/wexapp/model/PurchaseTransaction.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -29,6 +30,7 @@ public class PurchaseTransaction {
     @Column(name = "purchase_amount", nullable = false)
     @NotNull(message = "Purchase amount must be a valid amount.")
     @Digits(integer = 10, message = "Purchase amount must be rounded to the nearest cent.", fraction = 9)
+    @Positive(message = "Purchase amount must be a positive value.")
     private BigDecimal purchaseAmount;
 
 

--- a/src/test/java/br/com/wexapplication/wexapp/controller/PurchaseTransactionCtrlTest.java
+++ b/src/test/java/br/com/wexapplication/wexapp/controller/PurchaseTransactionCtrlTest.java
@@ -92,6 +92,21 @@ public class PurchaseTransactionCtrlTest {
         assertEquals("Field description must not exceed 50 characters.", response.getBody().get(0));
     }
 
+    @Test
+    public void testSaveTransactionWithNegativeAmount() {
+        PurchaseTransactionRequest request = PurchaseTransactionRequest
+                .builder()
+                .transactionDate(LocalDate.now())
+                .purchaseAmount(new BigDecimal("-10"))
+                .description("Test Description")
+                .build();
+
+        ResponseEntity<ArrayList> response = restTemplate.postForEntity("http://localhost:"+port+"/api/purchase-transaction", request, ArrayList.class);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Purchase amount must be a positive value.", response.getBody().get(0));
+    }
+
 
     @Test
     public void testRetrieveConvertedPurchaseTransaction() {


### PR DESCRIPTION
## Summary
- enforce positive purchase amount in request DTO and entity model
- add regression test covering negative purchase amount

## Testing
- `gradle test` *(fails: Plugin org.springframework.boot not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845247df72883209894d8191cf264af